### PR TITLE
cp the pnpm store

### DIFF
--- a/derivation.nix
+++ b/derivation.nix
@@ -24,6 +24,7 @@ in
     , script ? "build"
     , distDir ? "dist"
     , copyNodeModules ? false
+    , copyPnpmStore ? true
     , extraBuildInputs ? [ ]
     , ...
     }@attrs:
@@ -53,7 +54,13 @@ in
         buildPhase = ''
           store=$(pnpm store path)
           mkdir -p $(dirname $store)
-          ln -s ${pnpmStore} $(pnpm store path)
+          # solve pnpm: EACCES: permission denied, copyfile '/build/.pnpm-store
+
+          ${if !copyPnpmStore
+          then "ln -s"
+          else "cp -RL"
+           } ${pnpmStore} $(pnpm store path)
+
           pnpm install --frozen-lockfile --offline
         '';
 


### PR DESCRIPTION
Fixes:  permission denied

issue output:
```
     > Progress: resolved 833, reused 61, downloaded 0, added 61
       >  EACCES  EACCES: permission denied, copyfile '/build/.pnpm-store/v3/files/74/c9e58a4b95fb42589e23fcd027b1374d2c61da1138ae1e52444096af057beb5ac788b46f70cc395e9108a781cf9d0a5a56e45919d11de0ebe453d7003b7610' -> '/build/node_modules/.pnpm/eslint-plugin-antfu@0.35.3_ycpbpc6yetojsgtrx3mwntkhsu/node_modules/_tmp_48_324add1f380348648b7b24fcecd8e85e/dist/index.cjs'
       >
       > pnpm: EACCES: permission denied, copyfile '/build/.pnpm-store/v3/files/74/c9e58a4b95fb42589e23fcd027b1374d2c61da1138ae1e52444096af057beb5ac788b46f70cc395e9108a781cf9d0a5a56e45919d11de0ebe453d7003b7610' -> '/build/node_modules/.pnpm/eslint-plugin-antfu@0.35.3_ycpbpc6yetojsgtrx3mwntkhsu/node_modules/_tmp_48_324add1f380348648b7b24fcecd8e85e/dist/index.cjs'
```