### PR TITLE
revert: chmod operation

### DIFF
--- a/derivation.nix
+++ b/derivation.nix
@@ -106,6 +106,8 @@ in
                   else "cp -RL"
                 } ${passthru.pnpmStore} $(pnpm store path)
 
+                ${lib.optionalString copyPnpmStore "chmod -R +w $(pnpm store path)"}
+
                 pnpm install --frozen-lockfile --offline
               '';
 


### PR DESCRIPTION
Sorry about that, I realized the chomd was still necessary when I was packing `https://github.com/opf/openproject/tree/dev/frontend`.