### PR TITLE
feat: support sha1 integrity hashes

### DIFF
--- a/lockfile.nix
+++ b/lockfile.nix
@@ -50,10 +50,16 @@ rec {
               baseName = last (splitString "/" (withoutVersion n));
               version = getVersion n;
             in
-            fetchurl {
-              url = "${registry}/${name}/-/${baseName}-${version}.tgz";
-              sha512 = v.resolution.integrity;
-            }
+            fetchurl (
+              {
+                url = "${registry}/${name}/-/${baseName}-${version}.tgz";
+              } // (
+                if hasPrefix "sha1-" v.resolution.integrity then
+                  { sha1 = v.resolution.integrity; }
+                else
+                  { sha512 = v.resolution.integrity; }
+              )
+            )
           else
             gitTarball n v
         )


### PR DESCRIPTION
pnpm also supports sha1 hashes for integrity checks (see here: https://github.com/pnpm/npm-registry-client/blob/6d9f7ec580979e97c3fbc3fa17ea26f2a410d96f/lib/publish.js#L88). This PR adds support for them.