### PR TITLE
fixed custom registry

### DIFF
--- a/lockfile.nix
+++ b/lockfile.nix
@@ -52,7 +52,7 @@ rec {
             in
             fetchurl (
               {
-                url = "${registry}/${name}/-/${baseName}-${version}.tgz";
+                url = v.resolution.tarball or "${registry}/${name}/-/${baseName}-${version}.tgz";
               } // (
                 if hasPrefix "sha1-" v.resolution.integrity then
                   { sha1 = v.resolution.integrity; }


### PR DESCRIPTION
Added support for downloading packages form a custom registry. 

Example:
https://github.com/tlm-solutions/kindergarten/blob/430ced4b200fa0d88fd38a2a4d9eefe1b3141082/pnpm-lock.yaml#L2111

using provided url in `tarball` instead of building it against the default npm registry.