### PR TITLE
Ignore scripts when building nodeModules

### DIFF
--- a/derivation.nix
+++ b/derivation.nix
@@ -142,7 +142,7 @@ in
               '';
 
               installPhase = ''
-                cp -r node_modules/. $out
+                cp -ar node_modules/. $out
               '';
             };
           };

--- a/derivation.nix
+++ b/derivation.nix
@@ -142,7 +142,7 @@ in
               '';
 
               installPhase = ''
-                cp -rvP node_modules/. $out
+                cp -a node_modules/. $out
               '';
             };
           };

--- a/derivation.nix
+++ b/derivation.nix
@@ -142,7 +142,7 @@ in
               '';
 
               installPhase = ''
-                cp -arv node_modules/. $out
+                cp -rP node_modules/. $out
               '';
             };
           };

--- a/derivation.nix
+++ b/derivation.nix
@@ -51,7 +51,9 @@ in
           inherit src name nativeBuildInputs;
 
           postUnpack = ''
+            export HOME=$NIX_BUILD_TOP # Some packages need a writable HOME
             pnpm store add ${concatStringsSep " " (unique (dependencyTarballs { inherit registry; lockfile = pnpmLockYaml; }))}
+            cp ${patchedLockfileYaml} "pnpm-lock.yaml"
           '';
 
           configurePhase = ''

--- a/derivation.nix
+++ b/derivation.nix
@@ -138,7 +138,7 @@ in
 
                 ${lib.optionalString copyPnpmStore "chmod -R +w $(pnpm store path)"}
 
-                pnpm install --frozen-lockfile --offline
+                pnpm install --frozen-lockfile --offline --ignore-scripts
               '';
 
               installPhase = ''

--- a/derivation.nix
+++ b/derivation.nix
@@ -138,7 +138,7 @@ in
 
                 ${lib.optionalString copyPnpmStore "chmod -R +w $(pnpm store path)"}
 
-                pnpm install --frozen-lockfile --offline --ignore-scripts
+                pnpm install --frozen-lockfile --offline
               '';
 
               installPhase = ''

--- a/derivation.nix
+++ b/derivation.nix
@@ -43,7 +43,7 @@ in
         pkg-config
       ] ++ extraBuildInputs;
       patchedLockfile = patchLockfile pnpmLockYaml;
-      patchedLockfileYaml = writeText "pnpm-lock.yaml" (toJSON passthru.patchedLockfile);
+      patchedLockfileYaml = writeText "pnpm-lock.yaml" (toJSON patchedLockfile);
     in
     stdenv.mkDerivation (
       recursiveUpdate

--- a/derivation.nix
+++ b/derivation.nix
@@ -142,7 +142,7 @@ in
               '';
 
               installPhase = ''
-                cp -rP node_modules/. $out
+                cp -rvP node_modules/. $out
               '';
             };
           };

--- a/derivation.nix
+++ b/derivation.nix
@@ -50,7 +50,7 @@ in
         (rec {
           inherit src name nativeBuildInputs;
 
-          unpackPhase = ''
+          postUnpack = ''
             pnpm store add ${concatStringsSep " " (unique (dependencyTarballs { inherit registry; lockfile = pnpmLockYaml; }))}
           '';
 

--- a/derivation.nix
+++ b/derivation.nix
@@ -142,7 +142,7 @@ in
               '';
 
               installPhase = ''
-                cp -ar node_modules/. $out
+                cp -arv node_modules/. $out
               '';
             };
           };

--- a/derivation.nix
+++ b/derivation.nix
@@ -55,8 +55,10 @@ in
             runHook preConfigure
 
             ${if installInPlace
-              then passthru.nodeModules.buildPhase
-              else ''
+              then ''
+                ${passthru.nodeModules.unpackPhase}
+                ${passthru.nodeModules.buildPhase}
+              '' else ''
                 ${if !copyNodeModules
                   then "ln -s"
                   else "cp -r"

--- a/derivation.nix
+++ b/derivation.nix
@@ -50,17 +50,14 @@ in
         (rec {
           inherit src name nativeBuildInputs;
 
-          postUnpack = ''
-            export HOME=$NIX_BUILD_TOP # Some packages need a writable HOME
-            pnpm store add ${concatStringsSep " " (unique (dependencyTarballs { inherit registry; lockfile = pnpmLockYaml; }))}
-            cp ${patchedLockfileYaml} "pnpm-lock.yaml"
-          '';
-
           configurePhase = ''
             export HOME=$NIX_BUILD_TOP # Some packages need a writable HOME
             export npm_config_nodedir=${nodejs}
 
             runHook preConfigure
+
+            pnpm store add ${concatStringsSep " " (unique (dependencyTarballs { inherit registry; lockfile = pnpmLockYaml; }))}
+            cp ${patchedLockfileYaml} "pnpm-lock.yaml"
 
             pnpm install --frozen-lockfile --offline
 

--- a/lockfile.nix
+++ b/lockfile.nix
@@ -29,6 +29,7 @@ let
             url = "https://${concatStringsSep "/" (init split)}.git";
             rev = (last split);
             shallow = true;
+            allRefs = true;
           };
     in
     # runCommand (last (init (traceValSeq (splitString "/" (traceValSeq (withoutVersion (traceValSeq n))))))) { } ''

--- a/lockfile.nix
+++ b/lockfile.nix
@@ -23,7 +23,7 @@ let
             }
         else
           let
-            split = splitString "/" v.id;
+            split = splitString "/" n;
           in
           fetchGit {
             url = "https://${concatStringsSep "/" (init split)}.git";


### PR DESCRIPTION
I work on a project which uses postinstall to do e.g. codegeneration. It feels like any postinstall script is unlikely to work properly in the nodeModules script, since no other source is copied across.