### PR TITLE
Add support for pnpm workspaces

### DIFF
--- a/derivation.nix
+++ b/derivation.nix
@@ -26,6 +26,7 @@ in
     , distDir ? "dist"
     , installInPlace ? false
     , installEnv ? { }
+    , buildEnv ? { }
     , noDevDependencies ? false
     , extraNodeModuleSources ? [ ]
     , copyPnpmStore ? true
@@ -68,6 +69,12 @@ in
           '';
 
           buildPhase = ''
+            ${concatStringsSep "\n" (
+              mapAttrsToList
+                (n: v: ''export ${n}="${v}"'')
+                buildEnv
+            )}
+
             runHook preBuild
 
             pnpm run ${script}
@@ -159,6 +166,6 @@ in
             };
 
         })
-        (attrs // { extraNodeModuleSources = null; installEnv = null; })
+        (attrs // { extraNodeModuleSources = null; installEnv = null; buildEnv = null;})
     );
 }


### PR DESCRIPTION
Currently a monorepo with multiple components doesn't work with the current pnpm2nix.

You can try to build the entire monorepo, but then fail to copy out all of the `node_modules` directories or you can try and build individual components, but pnpm complains if you pass it the project-wide lockfile for a specific component.

Add `workspace` and `components` as an alternative to `src`. When building the `node-modules` derivation, copy out the `node_modules` directory for every named component in addition to the `node_modules` directory at the root.

When building, pass the list of components as a filter to `pnpm run --recursive ${script}`. When doing the install, allow the user to specify which directories to copy out, with a default of `${component}/dist` for each component.

Currently doesn't have support for building individual components as separate derivations with shared `pnpm-store` and `node-modules` derivations.

This works for building a project where we needed workspace support.