### PR TITLE
Update lockfile.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702151865,
-        "narHash": "sha256-9VAt19t6yQa7pHZLDbil/QctAgVsA66DLnzdRGqDisg=",
+        "lastModified": 1736883708,
+        "narHash": "sha256-uQ+NQ0/xYU0N1CnXsa2zghgNaOPxWpMJXSUJJ9W7140=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "666fc80e7b2afb570462423cb0e1cf1a3a34fedd",
+        "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
         "type": "github"
       },
       "original": {

--- a/lockfile.nix
+++ b/lockfile.nix
@@ -1,6 +1,6 @@
 { lib
 , runCommand
-, remarshal
+, remarshal_0_17
 , fetchurl
 , ...
 }:
@@ -8,7 +8,7 @@
 with lib;
 rec {
 
-  parseLockfile = lockfile: builtins.fromJSON (readFile (runCommand "toJSON" { } "${remarshal}/bin/yaml2json ${lockfile} $out"));
+  parseLockfile = lockfile: builtins.fromJSON (readFile (runCommand "toJSON" { } "${remarshal_0_17}/bin/yaml2json ${lockfile} $out"));
 
   processLockfile = { registry, lockfile, noDevDependencies }:
     let


### PR DESCRIPTION
This pull request includes a slight change to the `lockfile.nix` file, pinning the `remarshal` package to `remarshal_0_17`, as remarshal 0.20 [dropped support for YAML 1.1](https://github.com/remarshal-project/remarshal?tab=readme-ov-file#yaml-12-only).

* `lockfile.nix`: Updated the reference from `remarshal` to `remarshal_0_17` to ensure compatibility with the specific version.